### PR TITLE
Add support for different Docker versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /home/node
 
 VOLUME /home/node/node_modules
 
-COPY package*.json .
+COPY package*.json ./
 
 RUN npm i -g npm@latest \
     && npm ci --legacy-peer-deps


### PR DESCRIPTION
## Change COPY line to achieve compatibility with different Docker versions.

Apparantly some different Docker versions do not support this format of destination directory, therefore `.` has been changed to `./`.

Otherwise it was resulting in the following error:
![image](https://user-images.githubusercontent.com/36543025/174850630-42672617-428b-4474-a1dd-a43eeec7da74.png)
